### PR TITLE
feat: Add support for custom configuration files

### DIFF
--- a/.changeset/lazy-beers-bake.md
+++ b/.changeset/lazy-beers-bake.md
@@ -1,0 +1,5 @@
+---
+"@kevintyj/prlint": minor
+---
+
+Add support for custom configuration files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           pnpm commitlint --version
 
       - name: 📝Validate PR commits with commitlint
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' }}
         run: pnpm commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
       - name: 🤞Run CI command

--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -33,3 +33,5 @@ jobs:
 
       - name: 📝Validate PR title with commitlint
         uses: ./
+        with:
+          cl-config: commitlint.config.js

--- a/README.md
+++ b/README.md
@@ -41,28 +41,37 @@ jobs:
           cache: pnpm
       - name: 🛠️Install dependencies for prlint
         run: pnpm install @commitlint/config-conventional
-      - name: 🧾Print versions
-        run: |
-          git --version
-          node --version
-          pnpm --version
-          pnpm commitlint --version
       - name: 📝Validate PR title with commitlint
         uses: kevintyj/prlint@v1
+        # Optional
+        with:
+          cl-config: commitlint-cjs.config.cjs
 ```
 The above action only check's out the current repository to fetch the commitlint configuration file.
 PNPM and node is used to install necessary dependencies, then config-conventional is used as a default config.
 When using the above configuration, `pnpm-lock.yaml` is required. Please use npm and node if `package-lock.json` is used.
 
+### Inputs
+#### `cl-config`
+**Optional** Path to commit lint config. Default : `'commitlint.config.js'`
+
+### Outputs 
+#### `lint-status`
+Status of the lint result. Returns `✅ Commitlint tests passed!` if successful and `❌ Commitlint tests failed` if 
+linter tests fail.
+#### `lint-details`
+Output of the commitlint result.
+
 ### Limitations
-The current action of Prlint only accepts `commitlint.config.js` based configurations on commitlint. 
-`v1.0.1` introduced support for ESM based configuration files. However, currently there is no support for configuration 
-files of different name in the repository such as `commitlintrc` files especially of different file types. 
-Future support for an `js` file input will be enabled through an optional action input. However, no support for `json` 
-or `yaml` files are currently planned. Please feel free to contribute to add aditional features!
+The current action of Prlint only accepts javascript based configurations on commitlint. 
+`v1.0.1` introduced support for ESM based configuration files. `v1.1.0` introduced support for custom config file names.
+However, due to ESM support added in `v1.0.1` non `js` config files such as `yaml` or `json` is not supported.
 
 Even if the project does not use `config-conventional`, the Prlint uses the configuration as a fallback, therefore the 
-project must contain the `config-conventional` package as a development dependency. 
+project must contain the `config-conventional` package as a development dependency.
+
+## Changelog
+See [CHANGELOG](CHANGELOG.md) for the release details
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,11 @@ description: Ensure PR title match commitlint config
 runs:
   using: node20
   main: dist/index.js
+inputs:
+  cl-config:
+    description: Path to commit lint config (commitlint.config.js)
+    default: commitlint.config.js
+    required: false
 outputs:
   lint-status:
     description: The status of the PR lint

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as github from '@actions/github';
+import * as core from '@actions/core';
 import handleError from './errHandle';
 import { verifyTitle } from './lint';
 
@@ -9,6 +10,7 @@ type pullRequest = {
 
 async function run(): Promise<void> {
 	const pullRequestPayload = github.context.payload.pull_request;
+	const configPayload = core.getInput('cl-config');
 
 	if (!pullRequestPayload?.title)
 		throw new Error('Pull Request or Title not found!');
@@ -18,7 +20,7 @@ async function run(): Promise<void> {
 		number: pullRequestPayload.number,
 	};
 
-	await verifyTitle(pullRequestObject.title, 'commitlint.config.js');
+	await verifyTitle(pullRequestObject.title, configPayload);
 }
 
 run().catch(handleError);

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -82,6 +82,8 @@ export async function verifyTitle(title: string, configPath: string = ''): Promi
 		return true;
 	}
 	else {
+		setOutput('lint-status', '❌ Commitlint tests failed\n');
+		setOutput('lint-details', linterResult);
 		const errors = linterResult.errors.map((error) => {
 			return `${error.name}: ${error.message}`;
 		}).join('\n');


### PR DESCRIPTION
## What is the purpose of this PR?
Adds the ability for users to input a explicit `javascript` configuration file path for commitlint

## ClickUp/Jira/Github project ticket number(s)?

## What did you do?
Add a GitHub action input `cl-config` for the file path for commitlint on the repository.
README updated to reflect changes

## How do we test it?
Vitest tests passing & coverage unchanged.

## Checklist before merging
- [x] Added tests where necessary
- [x] Performed a self-review of my code
- [x] Ensure all acceptance criteria are met
- [x] Implemented the UI as exactly as the design (applicable only for UI changes)
- [x] Added comments for codes where hard-to-understand
- [x] Haven't pushed unnecessary files (ex: `.env`, `.map`)
- [x] Haven't ignored Typescript warnings in the code (if do so add a comment with the reason)

## Provide screenshot details of the PR

## [optional] Tests passed screenshot

## [optional] Breaking changes after PR

## Anything else?
